### PR TITLE
Preserve `%` in stripped comments

### DIFF
--- a/arxiver.py
+++ b/arxiver.py
@@ -58,7 +58,7 @@ def process(deps, out_tar, args):
             with open(dep) as f, io.BytesIO() as g:
                 tarinfo = tarfile.TarInfo(name=dep)
                 content = f.read()
-                new_content = re.sub(r'(^|[^\\\n])%.*\n?', r"\1", content, flags=re.MULTILINE)
+                new_content = re.sub(r'(^|[^\\\n])%.*\n?', r"\1%", content, flags=re.MULTILINE)
                 g.write(new_content.encode('utf-8'))
                 tarinfo.size = g.tell()
                 g.seek(0)


### PR DESCRIPTION
LaTeX's `%` also comments out the newline, which has important properties in many contents (e.g. omitting whitespace between text on multiple lines). So it's much safer to keep the `%` and only strip the contents of the comment.